### PR TITLE
add ephemeral reviews functionality

### DIFF
--- a/data/swapiSchema.js
+++ b/data/swapiSchema.js
@@ -301,6 +301,13 @@ starships.forEach((ship) => {
   starshipData[ship.id] = ship;
 });
 
+var reviews = {
+  'NEWHOPE': [],
+  'EMPIRE': [],
+  'JEDI': []
+};
+
+
 /**
  * Helper function to get a character by ID.
  */
@@ -326,6 +333,13 @@ function getHero(episode) {
   }
   // Artoo is the hero otherwise.
   return droidData['2001'];
+}
+
+/**
+ * Allows us to fetch the ephemeral reviews for each episode
+ */
+function getReviews(episode) {
+  return reviews[episode];
 }
 
 /**
@@ -361,7 +375,7 @@ const resolvers = {
     human: (root, { id }) => getHuman(id),
     droid: (root, { id }) => getDroid(id),
     starship: (root, { id }) => getStarship(id),
-    reviews: () => null,
+    reviews: (root, { episode }) => getReviews(episode),
     search: (root, { text }) => {
       const re = new RegExp(text, 'i');
 
@@ -375,7 +389,10 @@ const resolvers = {
     },
   },
   Mutation: {
-    createReview: (root, { episode, review }) => review,
+    createReview: (root, { episode, review }) => {
+      reviews[episode].push(review);
+      return review;
+    },
   },
   Character: {
     __resolveType(data, context, info){


### PR DESCRIPTION
I've added an ephemeral reviews functionality so it does work while the server is up.

When running:
```graphql
{
  reviews(episode:NEWHOPE) {
    stars
    commentary
  }
}
```
now you get:
```json
{
  "data": {
    "reviews": []
  }
}
```

Then run:
```graphql
mutation {
  createReview(episode: NEWHOPE, review: {
    stars: 5
    commentary: "great movie"
  }) {
    stars
    commentary
  }
}
```
you get the same response as before:
```json
{
  "data": {
    "createReview": {
      "stars": 5,
      "commentary": "great movie"
    }
  }
}
```

But now you can repeat the first query:
```graphql
{
  reviews(episode:NEWHOPE) {
    stars
    commentary
  }
}
```
And you get (the expected)
```json
{
  "data": {
    "reviews": [
      {
        "stars": 5,
        "commentary": "great movie"
      }
    ]
  }
}
```
